### PR TITLE
Doxygen XML to Sphinx documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+# don't build extra formats (like HTML zip)
+formats:
+  - none
+
+# path to pip requirements file to bring in
+# doxygen extensions
+requirements_file: docs/requirements.txt
+
+python:
+  # make sure we're using Python 3
+  version: 3.5

--- a/docs/Doxyfile_rtd
+++ b/docs/Doxyfile_rtd
@@ -613,7 +613,7 @@ STRICT_PROTO_MATCHING  = NO
 # list. This list is created by putting \todo commands in the documentation.
 # The default value is: YES.
 
-GENERATE_TODOLIST      = YES
+GENERATE_TODOLIST      = NO
 
 # The GENERATE_TESTLIST tag can be used to enable (YES) or disable (NO) the test
 # list. This list is created by putting \test commands in the documentation.
@@ -1893,7 +1893,7 @@ MAN_LINKS              = NO
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = YES
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,9 @@
+@media screen and (min-width: 767px) {
+    .wy-table-responsive table td {
+	white-space: normal !important;
+    }
+
+    .wy-table-responsive {
+	overflow: visible !important;
+    }
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,4 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+<link href="{{ pathto('_static/theme_overrides.css', True) }}" rel="stylesheet" type="text/css">
+{% endblock %}

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,12 +1,10 @@
 .. _Modules:
 
+=======
 Modules
 =======
 
-.. raw:: html
-
-      <script type="text/javascript" src="../_static/jquery.js"></script>
-      <script> function resizeIframe(obj) { obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px'; } </script>
-
-      <!-- inline, after the iframe -->
-      <iframe src="../_static/namespaces.html" class="auto-height" width="100%" scrolling="no" marginheight="0" frameborder="0" onload="resizeIframe(this)"></iframe>
+.. autodoxysummary::
+   :toctree: generated/modules
+   :generate:
+   :kind: mod

--- a/docs/api/pages.rst
+++ b/docs/api/pages.rst
@@ -1,12 +1,16 @@
 .. _Pages:
 
+=====
 Pages
 =====
 
-.. raw:: html
+.. autodoxysummary::
+   :toctree: generated/pages
+   :generate:
+   :kind: page
 
-      <script type="text/javascript" src="../_static/jquery.js"></script>
-      <script> function resizeIframe(obj) { obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px'; } </script>
+.. toctree::
+   :glob:
+   :maxdepth: 1
 
-      <!-- inline, after the iframe -->
-      <iframe src="../_static/pages.html" class="auto-height" width="100%" height="600px" scrolling="yes" marginheight="0" frameborder="0" onload="resizeIframe(this)"></iframe>
+   generated/pages/*

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -7,12 +7,4 @@ API Reference
   :maxdepth: 1
 
   api/modules
-  api/annotated
   api/pages
-  api/files
-  api/classes
-  api/globals
-  api/globals_defs
-  api/globals_func
-  api/globals_vars
-  api/todo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinxfortran.fortran_domain',
 ]
 
-autosummary_generate = ['api_modules.rst', 'api_pages.rst']
+autosummary_generate = ['api/modules.rst', 'api/pages.rst']
 doxygen_xml = 'xml'
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,12 @@ if return_code != 0: sys.exit(return_code)
 # ones.
 extensions = [
     'sphinx.ext.mathjax',
+    'sphinxcontrib.autodoc_doxygen',
+    'sphinxfortran.fortran_domain',
 ]
+
+autosummary_generate = ['api_modules.rst', 'api_pages.rst']
+doxygen_xml = 'xml'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -137,7 +142,6 @@ html_theme = 'default'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 #html_static_path = ['_static']
-html_static_path = ['APIs']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+-e git+https://github.com/angus-g/sphinxcontrib-autodoc_doxygen.git#egg=sphinxcontrib-autodoc_doxygen
+-e git+https://github.com/angus-g/sphinx-fortran.git#egg=sphinx-fortran


### PR DESCRIPTION
I didn't make a full one-to-one translation of the Doxygen output, so there are a few things missing. Perhaps most notably are the call graphs, whose embedded links are formatted for the original Doxygen HTML output. It wouldn't be hard to add a flag to the doxygen_autodoc extension to include these anyway, if needed.