### PR TITLE
Remove AC_CHECK_FILE for legacy MOM_memory.h

### DIFF
--- a/ac/configure.ac
+++ b/ac/configure.ac
@@ -43,7 +43,6 @@ srcdir=$srcdir/..
 # NOTE: --enable is more properly used to add a feature, rather than to select
 #   a compile-time mode, so this is not exactly being used as intended.
 MEM_LAYOUT=${srcdir}/config_src/memory/dynamic_symmetric
-AC_CHECK_FILE($MEM_LAYOUT, [MEM_LAYOUT=$MEM_LAYOUT], [MEM_LAYOUT=${srcdir}/config_src/dynamic_symmetric])
 AC_ARG_ENABLE([asymmetric],
   AS_HELP_STRING([--enable-asymmetric], [Use the asymmetric grid]))
 AS_IF([test "$enable_asymmetric" = yes],


### PR DESCRIPTION
This patch removes the AC_CHECK_FILE autoconf macro which assigns a
default path to the MOM_memory.h file path.

This path was defaulting back to the old directory, and was added to
support the regression verification testing, but this is a regression
problem with should be handled by the regression, not the autoconf
configuration.

This ~will~ may produce a regression test fail, but it not a cause for concern.